### PR TITLE
Users can choose if the template should clobber the destination 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Copies recursively the files from source directory to destination directory.
 - Copy file directly if it is binary
 - Templating file if it is text file with [LoDash](http://lodash.com/docs#template)'s templating method
 
+> `settings.clobber` defaults to true, overwrites destination files
 > `settings.templateOptions` is [template-options](https://lodash.com/docs#template) just passed to `_.template`
 > `data` is used to interpolated the text files
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ var template = require('template-directory');
 template('/tmp/mydir', '/tmp/mynewdir', {
     name: 'hello'
 }, {
+  clobber: false,
   templateOptions: {variable: 'data'}
 });
 
@@ -38,10 +39,12 @@ Copies recursively the files from source directory to destination directory.
 
 - Copy file directly if it is binary
 - Templating file if it is text file with [LoDash](http://lodash.com/docs#template)'s templating method
+- `data` is used to interpolated the text files
 
-> `settings.clobber` defaults to true, overwrites destination files
-> `settings.templateOptions` is [template-options](https://lodash.com/docs#template) just passed to `_.template`
-> `data` is used to interpolated the text files
+Available settings:
+
+- `clobber`: defaults to true, overwrites destination files
+- `templateOptions` is [template-options](https://lodash.com/docs#template) just passed to `_.template`
 
 ## LICENSE ##
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ npm install template-directory --save-dev
 ```javascript
 var template = require('template-directory');
 
-template('/tmp/mydir', '/tmp/mynewdir', {variable: 'data'}, {
+template('/tmp/mydir', '/tmp/mynewdir', {
     name: 'hello'
+}, {
+  templateOptions: {variable: 'data'}
 });
 
-//if you don't have settings, make sure pass undefined as placeholder
-template('/tmp/mydir', '/tmp/mynewdir', undefined, {
+//if you don't have settings, you can simply omit it
+template('/tmp/mydir', '/tmp/mynewdir', {
     name: 'hello'
 });
 
@@ -30,14 +32,14 @@ template('/tmp/mydir', '/tmp/mynewdir', undefined, {
 template('/tmp/mydir', '/tmp/mynewdir');
 ```
 
-#### template(source, destination[, settings, data]) ####
+#### template(source, destination[, data, settings]) ####
 
 Copies recursively the files from source directory to destination directory.
 
 - Copy file directly if it is binary
 - Templating file if it is text file with [LoDash](http://lodash.com/docs#template)'s templating method
 
-> `settings` is [template-options](https://lodash.com/docs#template) just passed to `_.template`  
+> `settings.templateOptions` is [template-options](https://lodash.com/docs#template) just passed to `_.template`
 > `data` is used to interpolated the text files
 
 ## LICENSE ##

--- a/index.js
+++ b/index.js
@@ -8,19 +8,21 @@ var log = require('pretty-log');
 var _ = require('lodash');
 var fs = require('fs');
 
-var copy = function(source, dest, settings, data) {
+var copy = function(source, dest, data, settings) {
+    var localSettings = settings || {}
+
     if (isBinaryFile.sync(source)) {
         fse.copySync(source, dest);
     } else {
         fse.ensureDirSync(path.dirname(dest));
 
         var txt = fs.readFileSync(source, {encoding: 'utf8'});
-        var out = _.template(txt, settings)(data);
+        var out = _.template(txt, localSettings.templateOptions)(data);
         fs.writeFileSync(dest, out, {encoding: 'utf8'});
     }
 };
 
-module.exports = function(source, destination, settings, data) {
+module.exports = function(source, destination, data, settings) {
     var src = source || './';
 
     if (!source) {
@@ -39,6 +41,6 @@ module.exports = function(source, destination, settings, data) {
 
     files.forEach(function(file) {
         var dest = path.join(destination, file);
-        copy(path.join(src, file), dest, settings, data);
+        copy(path.join(src, file), dest, data, settings);
     });
 };

--- a/index.js
+++ b/index.js
@@ -8,8 +8,21 @@ var log = require('pretty-log');
 var _ = require('lodash');
 var fs = require('fs');
 
+var fileExists = function (file) {
+    try {
+        fs.statSync(file)
+        return true
+    } catch (e) {
+        return false
+    }
+}
+
 var copy = function(source, dest, data, settings) {
-    var localSettings = settings || {}
+    var localSettings = _.merge({clobber: true}, settings);
+
+    if (!localSettings.clobber && fileExists(dest)) {
+        return;
+    }
 
     if (isBinaryFile.sync(source)) {
         fse.copySync(source, dest);

--- a/test/basic.js
+++ b/test/basic.js
@@ -28,6 +28,26 @@ describe('basic test', function() {
         done();
     });
 
+    describe('given an existing file in the destination', function() {
+        beforeEach(function() {
+            fse.ensureFileSync(path.resolve(dest, 'nest', 'nesta.txt'));
+        });
+
+        it('should be overwriten by default', function() {
+            template(src, dest);
+            should(fs.readFileSync(path.resolve(dest, 'nest', 'nesta.txt'), {
+                encoding: 'utf8'
+            })).eql('nestaaa\n', 'not same');
+        });
+
+        it('should be possible to not clobber the destination files', function() {
+            template(src, dest, {}, {clobber: false});
+            should(fs.readFileSync(path.resolve(dest, 'nest', 'nesta.txt'), {
+                encoding: 'utf8'
+            })).eql('', 'not same');
+        });
+    });
+
     afterEach(function() {
         fse.removeSync(dest);
     });

--- a/test/basic.js
+++ b/test/basic.js
@@ -11,7 +11,7 @@ describe('basic test', function() {
     var dest = path.resolve(__dirname, 'ttt');
 
     it('all good', function(done) {
-        template(src, dest, {variable: 'name'});
+        template(src, dest, {}, {templateOptions: {variable: 'name'}});
         should(fs.readFileSync(path.resolve(dest, 'nest', 'nesta.txt'), {
             encoding: 'utf8'
         })).eql('nestaaa\n', 'not same');
@@ -19,8 +19,8 @@ describe('basic test', function() {
     });
 
     it('with variable', function(done) {
-        template(src, dest, {interpolate: /%([\s\S]+?)%/}, {
-            name: 'nanfeng'
+        template(src, dest, {name: 'nanfeng'}, {
+            templateOptions: {interpolate: /%([\s\S]+?)%/}
         });
         should(fs.readFileSync(path.resolve(dest, 'nest', 'nestb.txt'), {
             encoding: 'utf8'


### PR DESCRIPTION
I had to do a **breaking change** in the public API while implementing this feature.

First, I had to move the options passed to the handlebars template as an attribute of the `settings` argument, giving room for the extra `clobber` setting.

While doing this change, I've also moved the `settings` as the last argument, given it is often less defined than the `data` 

Let me know if that is OK. It should reflect in another major release of the package.

The name `clobber` was taken from the [fs-extra documentation](https://github.com/jprichardson/node-fs-extra#copy).
